### PR TITLE
change export const enum to export enum 

### DIFF
--- a/src/parse/GedcomReadingPhase.ts
+++ b/src/parse/GedcomReadingPhase.ts
@@ -1,7 +1,7 @@
 /**
  * Reading phases.
  */
-export const enum GedcomReadingPhase {
+export enum GedcomReadingPhase {
     Decoding,
     TokenizationAndStructuring,
     Indexing,

--- a/src/parse/decoder.ts
+++ b/src/parse/decoder.ts
@@ -7,7 +7,7 @@ import { decodeUtfBOM } from './decoding';
 /**
  * Supported Gedcom file encoding schemes.
  */
-export const enum FileEncoding {
+export enum FileEncoding {
     Utf8 = 'UTF-8',
     Ansel = 'ANSEL',
     Cp1252 = 'Cp1252',

--- a/src/tag/Tag.ts
+++ b/src/tag/Tag.ts
@@ -3,7 +3,7 @@
 /**
  * All the standard Gedcom tags.
  */
-export const enum Tag {
+export enum Tag {
     Abbreviation = 'ABBR',
     Address = 'ADDR',
     Address1 = 'ADR1',

--- a/src/tag/TagNonStandard.ts
+++ b/src/tag/TagNonStandard.ts
@@ -1,6 +1,6 @@
 /**
  * Opinionated enumeration of common non-standard Gedcom tags.
  */
-export const enum TagNonStandard {
+export enum TagNonStandard {
     CharacterAlt = 'CHARACTER',
 }

--- a/src/value/ValueAdoption.ts
+++ b/src/value/ValueAdoption.ts
@@ -1,4 +1,4 @@
-export const enum ValueAdoption {
+export enum ValueAdoption {
     Husband = 'HUSB',
     Wife = 'WIFE',
     Both = 'BOTH'

--- a/src/value/ValueCertainty.ts
+++ b/src/value/ValueCertainty.ts
@@ -1,4 +1,4 @@
-export const enum ValueCertainty {
+export enum ValueCertainty {
     Unreliable = 0,
     Questionable = 1,
     Secondary = 2,

--- a/src/value/ValueCharacterEncoding.ts
+++ b/src/value/ValueCharacterEncoding.ts
@@ -1,4 +1,4 @@
-export const enum ValueCharacterEncoding {
+export enum ValueCharacterEncoding {
     Utf8 = 'UTF-8',
     Unicode = 'UNICODE', // While technically not the name of a charset, it is used by some software (and also part of the Gedcom specification)
     Ansel = 'ANSEL',

--- a/src/value/ValueEvent.ts
+++ b/src/value/ValueEvent.ts
@@ -1,3 +1,3 @@
-export const enum ValueEvent {
+export enum ValueEvent {
     Yes = 'Y'
 }

--- a/src/value/ValueGedcomForm.ts
+++ b/src/value/ValueGedcomForm.ts
@@ -1,3 +1,3 @@
-export const enum ValueGedcomForm {
+export enum ValueGedcomForm {
     LineageLinked = 'LINEAGE-LINKED'
 }

--- a/src/value/ValueLanguage.ts
+++ b/src/value/ValueLanguage.ts
@@ -1,4 +1,4 @@
-export const enum ValueLanguage {
+export enum ValueLanguage {
     Afrikaans = 'Afrikaans',
     Albanian = 'Albanian',
     AngloSaxon = 'Anglo-Saxon',

--- a/src/value/ValueMediaType.ts
+++ b/src/value/ValueMediaType.ts
@@ -1,4 +1,4 @@
-export const enum ValueMediaType {
+export enum ValueMediaType {
     Audio = 'audio',
     Book = 'book',
     Card = 'card',

--- a/src/value/ValueMultimediaFormat.ts
+++ b/src/value/ValueMultimediaFormat.ts
@@ -1,4 +1,4 @@
-export const enum ValueMultimediaFormat {
+export enum ValueMultimediaFormat {
     Aac = 'AAC',
     Avi = 'AVI',
     Bmp = 'BMP',

--- a/src/value/ValueNameType.ts
+++ b/src/value/ValueNameType.ts
@@ -1,4 +1,4 @@
-export const enum ValueNameType {
+export enum ValueNameType {
     Alias = 'aka',
     Birth = 'birth',
     Immigration = 'immigrant',

--- a/src/value/ValuePedigreeLinkageType.ts
+++ b/src/value/ValuePedigreeLinkageType.ts
@@ -1,4 +1,4 @@
-export const enum ValuePedigreeLinkageType {
+export enum ValuePedigreeLinkageType {
     Adopted = 'adopted',
     Birth = 'birth',
     Foster = 'foster'

--- a/src/value/ValuePhonetizationMethod.ts
+++ b/src/value/ValuePhonetizationMethod.ts
@@ -1,4 +1,4 @@
-export const enum ValuePhonetizationMethod {
+export enum ValuePhonetizationMethod {
     Hangul = 'Hangul',
     Kana = 'kana'
 }

--- a/src/value/ValueRole.ts
+++ b/src/value/ValueRole.ts
@@ -1,4 +1,4 @@
-export const enum ValueRole {
+export enum ValueRole {
     // Due to TS limitations, we cannot reuse values from `Tag`
     Child = 'CHIL',
     Husband = 'HUSB',

--- a/src/value/ValueRomanizationMethod.ts
+++ b/src/value/ValueRomanizationMethod.ts
@@ -1,4 +1,4 @@
-export const enum ValueRomanizationMethod {
+export enum ValueRomanizationMethod {
     Pinyin = 'pinyin',
     Romaji = 'romaji',
     Wadegiles = 'wadegiles'

--- a/src/value/ValueSex.ts
+++ b/src/value/ValueSex.ts
@@ -1,4 +1,4 @@
-export const enum ValueSex {
+export enum ValueSex {
     Male = 'M',
     Female = 'F',
     Intersex = 'X',

--- a/src/value/ValueSourceCertainty.ts
+++ b/src/value/ValueSourceCertainty.ts
@@ -1,4 +1,4 @@
-export const enum ValueSourceCertainty {
+export enum ValueSourceCertainty {
     Unreliable = 0,
     Questionable = 1,
     Secondary = 2,


### PR DESCRIPTION
const enums cause errors with either isolatedModules or verbatimmodulesyntax,
See https://www.typescriptlang.org/tsconfig#isolatedModules for example

This pull request is one possible fix, it changes the const enums to simply enums.  I'm not sure this is the right fix, https://www.typescriptlang.org/docs/handbook/enums.html#ambient-enums suggests that changing them to const objects may be better.  